### PR TITLE
Refactor/use persistent weaviate client

### DIFF
--- a/tempo_embeddings/embeddings/weaviate_database.py
+++ b/tempo_embeddings/embeddings/weaviate_database.py
@@ -41,8 +41,7 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
         self.embedder_config = embedder_config
         self.tokenizer = AutoTokenizer.from_pretrained(embedder_name) if embedder_name else None
         self.model = None
-        self.client = None # FIXME: this is never used, instead a new client is initialized in every call
-        self.weaviate_headers = {}
+        weaviate_headers = {}
         
         creating_new_db = True
         if self.embedder_config is None:
@@ -53,7 +52,7 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
                 raise FileNotFoundError("No existing configuration was found for this Database. Did you provide the right path?")
         elif self.embedder_config.get("type") == "hf":
             self.embedding_function = wvc.config.Configure.Vectorizer.text2vec_huggingface(model=self.embedder_name)
-            self.weaviate_headers = {"X-HuggingFace-Api-Key": self.embedder_config["api_key"]}
+            weaviate_headers["X-HuggingFace-Api-Key"] = self.embedder_config["api_key"]
         elif self.embedder_config.get("type") == "custom_model" or self.embedder_config.get("type") == "default":
             try:
                 self.model = self.embedder_config.get("model")
@@ -72,14 +71,13 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
                 "existing_collections": [],
             }
             self._save_config()
-        
+
+        self._client = weaviate.connect_to_local(headers=weaviate_headers)
+
         
     def connect(self):
-        with weaviate.connect_to_local() as client:
-            # TODO: add functionality for connecting to remote database
-            logger.info(type(client))
-            logger.info("Weaviate Server Is Up: %s", client.is_ready())
-            return client.is_ready()
+        # FIXME: Rename this method to is_ready() to match the VectorDatabaseManagerWrapper interface
+        return self._client.is_ready
 
 
     def _save_config(self):
@@ -127,64 +125,61 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
         
 
     def delete_collection(self, name):
-        with weaviate.connect_to_local() as client:
-            try:
-                client.collections.delete(name)
-                self.config["existing_collections"] = [c for c in self.config["existing_collections"] if c != name]
-                self._save_config()
-                logger.info("Succesfully deleted %s", name)
-            except Exception as e:
-                logger.error("delete_collection() with name '%s' caused exception %s", name, e)
+        try:
+            self._client.collections.delete(name)
+            self.config["existing_collections"] = [c for c in self.config["existing_collections"] if c != name]
+            self._save_config()
+            logger.info("Succesfully deleted %s", name)
+        except Exception as e:
+            # TODO: make exception handling more specific
+            logger.error("delete_collection() with name '%s' caused exception %s", name, e)
 
 
     def get_collection_count(self, name):
-        with weaviate.connect_to_local() as client:
-            collection = client.collections.get(name)
-            response = collection.aggregate.over_all(total_count=True)
-            return response.total_count
+        collection = self._client.collections.get(name)
+        response = collection.aggregate.over_all(total_count=True)
+        return response.total_count
 
     def _insert_using_custom_model(self, corpus, collection):
         num_records = 0
         embeddings = self.model.embed_corpus(corpus, store_tokenizations=True, batch_size=self.batch_size)
-        with weaviate.connect_to_local(headers=self.weaviate_headers) as client:
-            collection_obj = client.collections.get(collection)
-            for batch_pass, batch_embeds in zip(corpus.batches(self.batch_size), embeddings):
-                logger.debug("Batch pass... %s | %s", type(batch_pass), type(batch_embeds))
-                logger.debug("NODE: %s", platform.node())
-                data_objects = []
-                # Prepare Insertion Batch...
-                for p, emb in zip(batch_pass, [tensor.tolist() for tensor in batch_embeds]):
-                    props = p.metadata
-                    props['passage'] = p.text
-                    props['highlighting'] = str(p.highlighting)
-                    #properties = {"passage": p.text, "title": p.metadata['title'], "date": datetime.strptime(p.metadata['date'],'%Y-%m-%d'), 
-                    #               "issuenumber": int(p.metadata['issuenumber'])}
-                    data_object = wvc.data.DataObject(
-                        properties=props,
-                        uuid=generate_uuid5(props),
-                        vector=emb
-                    )
-                    data_objects.append(data_object)
-                # Make the Insertion
-                response = collection_obj.data.insert_many(data_objects)
-                num_records += len(response.all_responses)
+        collection_obj = self._client.collections.get(collection)
+        for batch_pass, batch_embeds in zip(corpus.batches(self.batch_size), embeddings):
+            logger.debug("Batch pass... %s | %s", type(batch_pass), type(batch_embeds))
+            logger.debug("NODE: %s", platform.node())
+            data_objects = []
+            # Prepare Insertion Batch...
+            for p, emb in zip(batch_pass, [tensor.tolist() for tensor in batch_embeds]):
+                props = p.metadata
+                props['passage'] = p.text
+                props['highlighting'] = str(p.highlighting)
+                #properties = {"passage": p.text, "title": p.metadata['title'], "date": datetime.strptime(p.metadata['date'],'%Y-%m-%d'), 
+                #               "issuenumber": int(p.metadata['issuenumber'])}
+                data_object = wvc.data.DataObject(
+                    properties=props,
+                    uuid=generate_uuid5(props),
+                    vector=emb
+                )
+                data_objects.append(data_object)
+            # Make the Insertion
+            response = collection_obj.data.insert_many(data_objects)
+            num_records += len(response.all_responses)
         return num_records
 
     def _insert_using_huggingface_api(self, corpus, collection):
         num_records = 0
-        with weaviate.connect_to_local(headers=self.weaviate_headers) as client:
-            collection_obj = client.collections.get(collection)
-            with collection_obj.batch.dynamic() as batch:
-                for p in corpus.passages:
-                    props = p.metadata
-                    props['passage'] = p.text
-                    props['highlighting'] = str(p.highlighting)
-                    batch.add_object(
-                        properties=props,
-                        uuid=generate_uuid5(props),
-                        # vector=self.model.embed_passage(p)
-                    )
-                num_records += len(corpus.passages)
+        collection_obj = self._client.collections.get(collection)
+        with collection_obj.batch.dynamic() as batch:
+            for p in corpus.passages:
+                props = p.metadata
+                props['passage'] = p.text
+                props['highlighting'] = str(p.highlighting)
+                batch.add_object(
+                    properties=props,
+                    uuid=generate_uuid5(props),
+                    # vector=self.model.embed_passage(p)
+                )
+            num_records += len(corpus.passages)
         return num_records
 
     def insert_corpus(self, collection: str, corpus: Corpus):
@@ -222,33 +217,32 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
                    where_obj: dict[str, Any] = None, 
                    include_embeddings: bool = False, 
                    limit: int = 10000):
-        with weaviate.connect_to_local() as client:
-            my_collection = client.collections.get(collection)
+        my_collection = self._client.collections.get(collection)
 
-            db_filter_words = Filter.by_property("passage").contains_any(filter_words) if filter_words and len(filter_words) > 0 else None
-            # TODO: How can we generalize the filtering?
-            if where_obj and 'year_from' in where_obj and 'year_to' in where_obj:
-                db_prop_filters = Filter.by_property("year").greater_or_equal(str(where_obj['year_from'])) & \
-                                    Filter.by_property("year").less_or_equal(str(where_obj['year_to']))
-                db_filters_all = db_filter_words & db_prop_filters
-            else:
-                db_filters_all = db_filter_words
+        db_filter_words = Filter.by_property("passage").contains_any(filter_words) if filter_words and len(filter_words) > 0 else None
+        # TODO: How can we generalize the filtering?
+        if where_obj and 'year_from' in where_obj and 'year_to' in where_obj:
+            db_prop_filters = Filter.by_property("year").greater_or_equal(str(where_obj['year_from'])) & \
+                                Filter.by_property("year").less_or_equal(str(where_obj['year_to']))
+            db_filters_all = db_filter_words & db_prop_filters
+        else:
+            db_filters_all = db_filter_words
+        
+        limit = limit if limit > 0 else None
+
+        response = my_collection.query.fetch_objects(
+            limit=limit,
+            filters=db_filters_all, 
+            include_vector=include_embeddings
+        )
+
+        if len(response.objects) > 0:
+            passages = [self._create_passage_from_record(o.uuid, o.properties, o.vector['default'] 
+                                                            if include_embeddings else None) 
+                                                            for o in response.objects]
+            return Corpus(passages, label="; ".join(filter_words) if filter_words else None) 
             
-            limit = limit if limit > 0 else None
-
-            response = my_collection.query.fetch_objects(
-                limit=limit,
-                filters=db_filters_all, 
-                include_vector=include_embeddings
-            )
-
-            if len(response.objects) > 0:
-                passages = [self._create_passage_from_record(o.uuid, o.properties, o.vector['default'] 
-                                                             if include_embeddings else None) 
-                                                             for o in response.objects]
-                return Corpus(passages, label="; ".join(filter_words) if filter_words else None) 
-            
-            return Corpus()
+        return Corpus()
     
     
     def query_vector_neighbors(
@@ -258,18 +252,18 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
         k_neighbors=10
     ) -> Iterable[tuple[Passage, float]]:
         
-        with weaviate.connect_to_local(headers=self.weaviate_headers) as client:
-            wv_collection = client.collections.get(collection)
-            response = wv_collection.query.near_vector(
-                near_vector=vector,
-                limit=k_neighbors,
-                include_vector=True,
-                return_metadata=MetadataQuery(distance=True)
-            )
+    
+        wv_collection = self._client.collections.get(collection)
+        response = wv_collection.query.near_vector(
+            near_vector=vector,
+            limit=k_neighbors,
+            include_vector=True,
+            return_metadata=MetadataQuery(distance=True)
+        )
 
-            for o in response.objects:
-                text = o.properties.pop("passage")
-                yield (Passage(text, o.properties, embedding=o.vector['default'], unique_id=o.uuid), o.metadata.distance)
+        for o in response.objects:
+            text = o.properties.pop("passage")
+            yield (Passage(text, o.properties, embedding=o.vector['default'], unique_id=o.uuid), o.metadata.distance)
     
 
     def query_text_neighbors(
@@ -279,48 +273,45 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
         k_neighbors=10
     ) -> Iterable[tuple[Passage, float]]:
         
-        with weaviate.connect_to_local(headers=self.weaviate_headers) as client:
-            wv_collection = client.collections.get(collection)
-            response = wv_collection.query.near_text(
-                query=text,
-                limit=k_neighbors,
-                include_vector=True,
-                return_metadata=MetadataQuery(distance=True)
-            )
+        wv_collection = self._client.collections.get(collection)
+        response = wv_collection.query.near_text(
+            query=text,
+            limit=k_neighbors,
+            include_vector=True,
+            return_metadata=MetadataQuery(distance=True)
+        )
 
-            for o in response.objects:
-                text = o.properties.pop("passage")
-                yield (Passage(text, o.properties, embedding=o.vector['default'], unique_id=o.uuid), o.metadata.distance)
+        for o in response.objects:
+            text = o.properties.pop("passage")
+            yield (Passage(text, o.properties, embedding=o.vector['default'], unique_id=o.uuid), o.metadata.distance)
 
 
     def export_from_collection(self, collection_name: str, filepath: str = None) -> None:
         filename_tgt = filepath or f"{collection_name}.json.gz"
-        with weaviate.connect_to_local() as client:
-            collection_src = client.collections.get(collection_name)
-            with gzip.open(filename_tgt, 'wt', encoding='utf-8') as fileout:
-                logging.info("Writing into '%s' file...", filename_tgt)
-                for q in tqdm(collection_src.iterator(include_vector=True)):
-                    row_dict = q.properties
-                    row_dict['vector'] = q.vector['default']
-                    row_dict['uuid'] = str(q.uuid)
-                    fileout.write(f'{json.dumps(row_dict)}\n')
+        collection_src = self._client.collections.get(collection_name)
+        with gzip.open(filename_tgt, 'wt', encoding='utf-8') as fileout:
+            logging.info("Writing into '%s' file...", filename_tgt)
+            for q in tqdm(collection_src.iterator(include_vector=True)):
+                row_dict = q.properties
+                row_dict['vector'] = q.vector['default']
+                row_dict['uuid'] = str(q.uuid)
+                fileout.write(f'{json.dumps(row_dict)}\n')
     
 
     def import_into_collection(self, filename_src: str, collection_name: str):
-        with weaviate.connect_to_local() as client:
-            collection_tgt = client.collections.get(collection_name)
-            with gzip.open(filename_src, 'rt', encoding='utf-8') as f:
-                logging.info("Importing into Weaviate '%s' collection...", filename_src)
-                if collection_name not in self.config["existing_collections"]:
-                    self.config["existing_collections"].append(collection_name)
-                    self._save_config()
-                with collection_tgt.batch.fixed_size(batch_size=self.batch_size) as batch:
-                    for line in tqdm(f):
-                        item = json.loads(line.strip())
-                        item_id = uuid.UUID(item.pop('uuid'))
-                        item_vector = item.pop('vector')
-                        batch.add_object(
-                            properties=item,
-                            vector=item_vector,
-                            uuid=item_id
-                        )
+        collection_tgt = self._client.collections.get(collection_name)
+        with gzip.open(filename_src, 'rt', encoding='utf-8') as f:
+            logging.info("Importing into Weaviate '%s' collection...", filename_src)
+            if collection_name not in self.config["existing_collections"]:
+                self.config["existing_collections"].append(collection_name)
+                self._save_config()
+            with collection_tgt.batch.fixed_size(batch_size=self.batch_size) as batch:
+                for line in tqdm(f):
+                    item = json.loads(line.strip())
+                    item_id = uuid.UUID(item.pop('uuid'))
+                    item_vector = item.pop('vector')
+                    batch.add_object(
+                        properties=item,
+                        vector=item_vector,
+                        uuid=item_id
+                    )

--- a/tempo_embeddings/embeddings/weaviate_database.py
+++ b/tempo_embeddings/embeddings/weaviate_database.py
@@ -84,6 +84,9 @@ class WeaviateDatabaseManager(VectorDatabaseManagerWrapper):
         if not self._client.connect():
             raise ConnectionError(f"Could not connect to Weaviate database with client: {str(self._client)}")
 
+    def __del__(self):
+        self._client.close()
+
     @property
     def client(self):
         return self._client

--- a/tempo_embeddings/text/abstractcorpus.py
+++ b/tempo_embeddings/text/abstractcorpus.py
@@ -46,6 +46,19 @@ class AbstractCorpus(ABC):
             else:
                 raise e
 
+    def has_embeddings(self) -> bool:
+        """Check if the corpus has embeddings.
+
+        For performance, this assumes consistency across all passages in the corpus, hence stops if any passage has an embedding.
+
+        Returns:
+            bool: True if the corpus has embeddings, False otherwise, including empty corpora.
+        """
+
+        return not any(passage.embedding is None for passage in self.passages) and any(
+            passage.embedding.any() for passage in self.passages
+        )
+
     @property
     @abstractmethod
     def vectorizer(self) -> TfidfVectorizer:

--- a/tempo_embeddings/text/corpus.py
+++ b/tempo_embeddings/text/corpus.py
@@ -23,7 +23,7 @@ class Corpus(AbstractCorpus):
         self._vectorizer: TfidfVectorizer = None
 
     def __add__(self, other: "Corpus", new_label: str = None) -> "Corpus":
-        if any(corpus.embeddings is not None for corpus in (self, other)):
+        if self.has_embeddings() or other.has_embeddings():
             logging.warning(
                 "Dropping existing embeddings to avoid inconsistent vector spaces."
             )

--- a/tests/unit/embeddings/test_weaviate_database.py
+++ b/tests/unit/embeddings/test_weaviate_database.py
@@ -1,26 +1,26 @@
 import pytest
-import weaviate
 from tempo_embeddings.embeddings.weaviate_database import WeaviateDatabaseManager
 
 
 @pytest.fixture
 def mock_weaviate_database_manager(mocker, tmp_path):
-    ### Mocking weaviate.connect_to_local context manager
-    # This should be unnecessary if we use a persistent weviate.Client object
-    mocker.patch("weaviate.connect_to_local").return_value.is_ready = True
+    mock_client = mocker.Mock()
 
     yield WeaviateDatabaseManager(
         db_path=tmp_path / "weaviate",
-        embedder_config={"type": "default", "model": mocker.MagicMock()},
+        embedder_config={"type": "default", "model": mocker.Mock()},
+        client=mock_client,
     )
-
-    weaviate.connect_to_local.assert_called_once()
 
 
 class TestWeaviateDatabase:
     def test_connect(self, mock_weaviate_database_manager):
         assert mock_weaviate_database_manager.connect()
 
-    @pytest.mark.skip(reason="mock not implemented")
     def test_get_collection_count(self, mock_weaviate_database_manager):
-        assert mock_weaviate_database_manager.get_collection_count("test") == 0
+        collection_name = "test"
+        mock_weaviate_database_manager.get_collection_count(collection_name)
+
+        mock_weaviate_database_manager.client.collections.get.assert_called_once_with(
+            collection_name
+        )

--- a/tests/unit/text/test_corpus.py
+++ b/tests/unit/text/test_corpus.py
@@ -175,6 +175,24 @@ class TestCorpus:
         corpus.embeddings = embeddings
         pd.testing.assert_frame_equal(corpus.embeddings_as_df(), expected)
 
+    @pytest.mark.parametrize(
+        "passages,expected",
+        [
+            ([], False),
+            ([Passage("test")], False),
+            ([Passage("test", embedding=np.random.rand(10))], True),
+            (
+                [
+                    Passage("test 1", embedding=np.random.rand(10)),
+                    Passage("test 2", embedding=np.random.rand(10)),
+                ],
+                True,
+            ),
+        ],
+    )
+    def test_has_embeddings(self, passages, expected):
+        assert Corpus(passages).has_embeddings() == expected
+
 
 class TestSubCorpus:
     def test_passages(self):


### PR DESCRIPTION
- Use persistent Weaviate client in WeaviateDatabaseManager to facilitate
  - reusing connections
  - use remote servers
  - testing
- fix check for existing embeddings
- adapt tests to mock Weaviate client

