### PR TITLE
Merge short sentences

### DIFF
--- a/tempo_embeddings/text/segmenter.py
+++ b/tempo_embeddings/text/segmenter.py
@@ -47,6 +47,16 @@ class Segmenter(abc.ABC):
         min_sentence_length: int = 20,
         max_sentence_length: int = 1000,
     ) -> None:
+        """The common constructor for inheriting segmenters.
+
+        Args:
+            language: the language code for the segmenter. Specifics depend on the segmenter.
+            min_sentence_length: the minimum length of a sentence in characters. Defaults to 20.
+            max_sentence_length: the maximum length of a sentence in characters. Defaults to 1000.
+
+        Raises:
+            ValueError: if min_sentence_length >= max_sentence_length.
+        """
         if min_sentence_length >= max_sentence_length:
             raise ValueError(
                 f"Minimum sentence length ({min_sentence_length}) must be less than maximum sentence length ({max_sentence_length})."
@@ -56,12 +66,11 @@ class Segmenter(abc.ABC):
         self._max_sentence_length = max_sentence_length
 
     @abc.abstractmethod
-    def split(self, text: str, *, min_sentence_length: int = 20) -> Iterable[str]:
+    def split(self, text: str) -> Iterable[str]:
         """Split the text into sentences.
 
         Args:
             text: the text to split.
-            min_sentence_length: the minimum length of a sentence. Defaults to 20.
         Returns:
             Iterable[str]: the sentences in the text.
         """
@@ -72,7 +81,6 @@ class Segmenter(abc.ABC):
 
         Args:
             sentences (list[str]): the sentences to merge.
-            min_sentence_length (int): the minimum length of a sentence. Defaults to 20.
         Yields:
             str: the merged sentences.
         """
@@ -145,8 +153,7 @@ class Segmenter(abc.ABC):
             str: the sentences after merging and splitting.
         """
         merged_sentences = self._merge_sentences(list(sentences))
-        split_sentences = self._split_sentences(merged_sentences)
-        return split_sentences
+        return self._split_sentences(merged_sentences)
 
     def passages(
         self,
@@ -322,6 +329,12 @@ class WindowSegmenter(Segmenter):
         **kwargs,
     ) -> None:
         super().__init__(language=language, **kwargs)
+
+        for arg in ("min_sentence_length", "max_sentence_length"):
+            if arg in kwargs:
+                logging.warning(
+                    f"{self.__class__.__name__} does not use '{arg}' argument."
+                )
 
         self._window_size = window_size
 

--- a/tempo_embeddings/text/segmenter.py
+++ b/tempo_embeddings/text/segmenter.py
@@ -105,26 +105,26 @@ class Segmenter(abc.ABC):
         Yields:
             str: the split sentences.
         """
+        split_at: Optional[int] = None
+
         if len(sentence) > self._max_sentence_length:
             center = len(sentence) // 2
 
-            right_semicolon: int = sentence.rfind(";", 1, center)
-            left_semicolon: int = sentence.find(";", center, len(sentence) - 2)
+            left_semicolon: int = sentence.rfind(";", 1, center)
+            right_semicolon: int = sentence.find(";", center, len(sentence) - 2)
 
             # TODO: use other delimiters
 
-            if right_semicolon == -1 and left_semicolon == -1:
+            if left_semicolon == -1 and right_semicolon == -1:
                 split_at = None  # No splitting marker found.
-            elif right_semicolon == -1:
-                split_at: int = left_semicolon
             elif left_semicolon == -1:
                 split_at = right_semicolon
-            elif abs(right_semicolon - center) < abs(left_semicolon - center):
-                split_at = right_semicolon
-            else:
+            elif right_semicolon == -1:
                 split_at = left_semicolon
-        else:
-            split_at = None
+            elif abs(left_semicolon - center) <= abs(right_semicolon - center):
+                split_at = left_semicolon
+            else:
+                split_at = right_semicolon
 
         if split_at is None:
             yield sentence.strip()

--- a/tempo_embeddings/text/segmenter.py
+++ b/tempo_embeddings/text/segmenter.py
@@ -40,16 +40,113 @@ class Segmenter(abc.ABC):
             backend = "cpu"
         return backend
 
+    def __init__(
+        self,
+        language: str,
+        *,
+        min_sentence_length: int = 20,
+        max_sentence_length: int = 1000,
+    ) -> None:
+        if min_sentence_length >= max_sentence_length:
+            raise ValueError(
+                f"Minimum sentence length ({min_sentence_length}) must be less than maximum sentence length ({max_sentence_length})."
+            )
+        self._language = language
+        self._min_sentence_length = min_sentence_length
+        self._max_sentence_length = max_sentence_length
+
     @abc.abstractmethod
-    def split(self, text: str) -> Iterable[str]:
+    def split(self, text: str, *, min_sentence_length: int = 20) -> Iterable[str]:
         """Split the text into sentences.
 
         Args:
             text: the text to split.
+            min_sentence_length: the minimum length of a sentence. Defaults to 20.
         Returns:
             Iterable[str]: the sentences in the text.
         """
         return NotImplemented
+
+    def _merge_sentences(self, sentences: list[str]) -> Iterable[str]:
+        """Merge short sentences into longer units.
+
+        Args:
+            sentences (list[str]): the sentences to merge.
+            min_sentence_length (int): the minimum length of a sentence. Defaults to 20.
+        Yields:
+            str: the merged sentences.
+        """
+        i = 0
+        while i < len(sentences):
+            current_sentence = sentences[i]
+            while len(current_sentence) < self._min_sentence_length:
+                i += 1
+                try:
+                    current_sentence += " " + sentences[i]
+                except IndexError:
+                    # FIXME: this can result in a final sentence that is too short
+                    break
+            yield current_sentence
+            i += 1
+
+    def _split_sentence(self, sentence: str) -> Iterable[str]:
+        """Split a sentence into shorter units.
+
+        Args:
+            sentence: the sentence to split.
+        Yields:
+            str: the split sentences.
+        """
+        if len(sentence) > self._max_sentence_length:
+            center = len(sentence) // 2
+
+            right_semicolon: int = sentence.rfind(";", 1, center)
+            left_semicolon: int = sentence.find(";", center, len(sentence) - 2)
+
+            # TODO: use other delimiters
+
+            if right_semicolon == -1 and left_semicolon == -1:
+                split_at = None  # No splitting marker found.
+            elif right_semicolon == -1:
+                split_at: int = left_semicolon
+            elif left_semicolon == -1:
+                split_at = right_semicolon
+            elif abs(right_semicolon - center) < abs(left_semicolon - center):
+                split_at = right_semicolon
+            else:
+                split_at = left_semicolon
+        else:
+            split_at = None
+
+        if split_at is None:
+            yield sentence.strip()
+        else:
+            split_at = split_at + 1  # Include the delimiter
+            yield from self._split_sentence(sentence[:split_at])
+            yield from self._split_sentence(sentence[split_at:])
+
+    def _split_sentences(self, sentences: Iterable[str]) -> Iterable[str]:
+        """Split long sentences into shorter units.
+
+        Args:
+            sentences: the sentences to split.
+        Yields:
+            str: the split sentences.
+        """
+        for sentence in sentences:
+            yield from self._split_sentence(sentence)
+
+    def _fit_lengths(self, sentences: Iterable[str]) -> list[str]:
+        """Fit the sentences to a minimum and maximum length.
+
+        Args:
+            sentences: the sentences to fit.
+        Yields:
+            str: the sentences after merging and splitting.
+        """
+        merged_sentences = self._merge_sentences(list(sentences))
+        split_sentences = self._split_sentences(merged_sentences)
+        return split_sentences
 
     def passages(
         self,
@@ -166,13 +263,12 @@ class Segmenter(abc.ABC):
 
 
 class SentenceSplitterSegmenter(Segmenter):
-    def __init__(self, language: str) -> None:
-        super().__init__()
-        self._model = SentenceSplitter(language=language)
-        self._language = language
+    def __init__(self, language: str, **kwargs) -> None:
+        super().__init__(language=language, **kwargs)
+        self._model = SentenceSplitter(language=self._language)
 
     def split(self, text: str) -> Iterable[str]:
-        return self._model.split(text)
+        return self._fit_lengths(self._model.split(text))
 
 
 class WtpSegmenter(Segmenter):
@@ -183,40 +279,49 @@ class WtpSegmenter(Segmenter):
         language: str,
         model: str = settings.WTPSPLIT_MODEL,
         style_or_domain: str = "-",
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(language=language, **kwargs)
 
         self._model = wtpsplit.SaT(
-            model, language=language, style_or_domain=style_or_domain
+            model, language=self._language, style_or_domain=style_or_domain
         )
 
         device: str = Segmenter.get_backend()
         logging.info("Using WtpSegemter on device: %s", device)
         self._model.half().to(device)
 
-    def split(self, text: str) -> list[str]:
-        return self._model.split(text)
+    def split(self, text: str) -> Iterable[str]:
+        return self._fit_lengths(self._model.split(text))
 
 
 class StanzaSegmenter(Segmenter):
     """A segmenter that uses the Stanza tokenizer."""
 
-    def __init__(self, language: str, *, processors: str = "tokenize") -> None:
-        super().__init__()
-        self._model = stanza.Pipeline(lang=language, processors=processors)
+    def __init__(
+        self, language: str, *, processors: str = "tokenize", **kwargs
+    ) -> None:
+        super().__init__(language=language, **kwargs)
+        self._model = stanza.Pipeline(lang=self._language, processors=processors)
 
     def split(self, text: str) -> Iterable[str]:
-        for sentence in self._model(text).sentences:
-            yield sentence.text
+        return self._fit_lengths(
+            (sentence.text for sentence in self._model(text).sentences)
+        )
 
 
 class WindowSegmenter(Segmenter):
     """A segmenter that uses a sliding window to segment text."""
 
     def __init__(
-        self, language: str, *, window_size: int, window_overlap: Optional[int] = None
+        self,
+        language=None,
+        *,
+        window_size: int,
+        window_overlap: Optional[int] = None,
+        **kwargs,
     ) -> None:
-        super().__init__()
+        super().__init__(language=language, **kwargs)
 
         self._window_size = window_size
 

--- a/tests/unit/text/test_segmenter.py
+++ b/tests/unit/text/test_segmenter.py
@@ -23,7 +23,11 @@ class TestSegmenter:
             ("This is a test.", 200, ["This is a test."]),
             ("This is; a test.", 200, ["This is; a test."]),
             ("This is; a test.", 5, ["This is;", "a test."]),
+            ("This; is a test.", 5, ["This;", "is a test."]),
+            ("This; is a; test.", 5, ["This;", "is a;", "test."]),
             ("This is a test.", 5, ["This is a test."]),
+            ("This; is a; test.", 12, ["This; is a;", "test."]),
+            ("This; is a; test.", 10, ["This;", "is a;", "test."]),
         ],
     )
     def test_split_sentence(self, sentence, max_sentence_length, expected):
@@ -59,6 +63,15 @@ class TestSegmenter:
                 19,
                 ["This is a sentence. Short."],
                 marks=pytest.mark.xfail(reason="Trailing short sentence."),
+            ),
+            pytest.param(
+                ["This is a sentence."],
+                2000,
+                ["This is a sentence."],
+                marks=pytest.mark.xfail(
+                    raises=ValueError,
+                    reason="Minimum sentence length must be smaller than maximum sentence length.",
+                ),
             ),
         ],
     )

--- a/tests/unit/text/test_segmenter.py
+++ b/tests/unit/text/test_segmenter.py
@@ -1,4 +1,5 @@
 import csv
+import logging
 from contextlib import nullcontext as does_not_raise
 from io import StringIO
 
@@ -247,8 +248,20 @@ class TestWindowSegmenter:
             ),
         ],
     )
-    def test_passages(self, text, window_size, window_overlap, expected):
-        segmenter = WindowSegmenter(
-            None, window_size=window_size, window_overlap=window_overlap
-        )
-        assert list(segmenter.passages(text)) == expected
+    def test_passages(self, text, window_size, window_overlap, expected, caplog):
+        with caplog.at_level(logging.WARNING):
+            passages = WindowSegmenter(
+                min_sentence_length=0,
+                window_size=window_size,
+                window_overlap=window_overlap,
+            ).passages(text)
+
+        assert caplog.record_tuples == [
+            (
+                "root",
+                logging.WARNING,
+                "WindowSegmenter does not use 'min_sentence_length' argument.",
+            )
+        ]
+
+        assert list(passages) == expected


### PR DESCRIPTION
# Changes
- Add `minimum_sentence_length` and `maximum_sentence_length` parameters to `Segmenter` and split/merge sentences accordingly.
- Splitting is based on semicolons which current sentence splitters do not use for splitting sentences

Fixes #100 

# Potential TODOs:
- use additional markers for sentence splitting
- if a short sentence has no successor for merging (the last sentence), it is left as it is
