### PR TITLE
Move NER-related dependencies to extra requirements `ner`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install .[dev,publishing]
+          python3 -m pip install .[dev,publishing,ner]
       - name: Run unit tests
         run: pytest -v
       - name: Verify that we can build the package

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install .[dev,publishing]
+          python3 -m pip install .[dev,publishing,ner]
       - name: Install pandoc using apt
-        run: sudo apt install pandoc        
+        run: sudo apt install pandoc
       - name: Build documentation
         run: make coverage doctest html
         working-directory: docs

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -29,7 +29,7 @@ jobs:
           which python3
           python3 --version
       - name: Install dependencies
-        run: python3 -m pip install .[dev]
+        run: python3 -m pip install .[dev,ner]
       - name: Run unit tests with coverage
         run: pytest --cov --cov-report term --cov-report xml --junitxml=xunit-result.xml tests/
       - name: Correct coverage paths

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,10 +58,7 @@ install_requires =
     datashader
     holoviews
     pandas
-    # Dependencies for NER pipeline and time space heat map:
-    folium~=0.18.0
-    geopy~=2.4.1
-    spacy~=3.8.2
+
 
 [options.data_files]
 # This section requires setuptools>=40.6.0
@@ -86,6 +83,11 @@ dev =
 publishing =
     twine
     wheel
+ner =
+    # Dependencies for NER pipeline and time space heat map:
+    folium~=0.18.0
+    geopy~=2.4.1
+    spacy~=3.8.2
 
 [options.packages.find]
 include = tempo_embeddings, tempo_embeddings.*


### PR DESCRIPTION
Avoid build errors on Windows related to Scipy.
